### PR TITLE
return actual value

### DIFF
--- a/is-defined-type.js
+++ b/is-defined-type.js
@@ -18,6 +18,7 @@
      * @returns {boolean}
      */
     var isDefinedType = function (input, path, type) {
+        var returnValue = false
 
         var nodes = [];
 
@@ -79,6 +80,11 @@
 
         }
 
+        if (types.indexOf('value') !== -1) {
+            types.splice(types.indexOf('value'), 1)
+            returnValue = true
+        }
+
         if (types.length) {
 
             var typeResult = false;
@@ -110,11 +116,11 @@
 
             }
 
-            return typeResult;
+            return typeResult ? returnValue ? current : true : false;
 
         } else {
 
-            return true;
+            return returnValue ? current : true;
 
         }
 


### PR DESCRIPTION
if you pass 'value' in the 3rd argument (as a string or in an array), then if the function finds the object, it returns the actual object/value.  This lets you use the module not just to verify if it exists, but as the item you are actually checking for.

is = require('is-defined-type')
var firstName = is(person,'data.name.first',['string','value']) || 'unspecified'